### PR TITLE
Deepfreeze the nextState object as well.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export function storeFreeze(reducer): ActionReducer<any> {
             throw error;
         }
 
+        deepFreeze(nextState);
+
         return nextState;
     };
 }


### PR DESCRIPTION
To avoid somebody tampering with the result of the reducer, you should deepFreeze the nextState object as well.
Otherwise, somebody who just takes the output of the store and starts changing this object will reflect changes into the store as well, since this will be the same reference.
You need to guard for a situation like this as well.