### PR TITLE
Deepfreeze the payload object as well.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export function storeFreeze(reducer): ActionReducer<any> {
     return function (state = {}, action) {
 
         deepFreeze(state);
+        deepFreeze(action.payload);
 
         let nextState;
 


### PR DESCRIPTION
Deepfreezing the payload as well guards you against someone adding something to the store and tampering with that object later on. F.e.

let user: User = {id: 1, name:"KwintenP"};

store.dispatch({type: "ADD_USER", payload: {user});

// Let's say someone changes this value in a form
user.name = "PKwinten";

Your store will also have 'PKwinten' as name property. The reducer which adds the user to the store will only copy it's reference into the users array, it will not create a copy. 
So you should deepFreeze the payload as well to guard from a situation like this.