### PR TITLE
Guard against undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export function storeFreeze(reducer): ActionReducer<any> {
 
         deepFreeze(state);
         
-        // guard against trying to free null or undefined types
+        // guard against trying to freeze null or undefined types
         if (action.payload) {
             deepFreeze(action.payload);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,11 @@ export function storeFreeze(reducer): ActionReducer<any> {
     return function (state = {}, action) {
 
         deepFreeze(state);
-        deepFreeze(action.payload);
+        
+        // guard against trying to free null or undefined types
+        if (action.payload) {
+            deepFreeze(action.payload);
+        }
 
         let nextState;
 


### PR DESCRIPTION
Fixes error when actions don't have a payload. Especially with ngrx-store it lead to a first action `{type: "@ngrx/store/init"}` with a deepfreeze of `undefined` which ended in an error `TypeError: Cannot convert undefined or null to object`