### PR TITLE
fix(storeFreeze): remove double error log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,7 @@ export function storeFreeze(reducer): ActionReducer<any> {
             deepFreeze(action.payload);
         }
 
-        let nextState;
-
-        try {
-            nextState = reducer(state, action);
-        } catch (error) {
-            console.error('State mutation is prohibited inside of reducers.');
-            throw error;
-        }
+        const nextState = nextState = reducer(state, action);
 
         deepFreeze(nextState);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export function storeFreeze(reducer): ActionReducer<any> {
             deepFreeze(action.payload);
         }
 
-        const nextState = nextState = reducer(state, action);
+        const nextState = reducer(state, action);
 
         deepFreeze(nextState);
 


### PR DESCRIPTION
This fixes a problem where any error inside a reducer will lead to the `State mutation` message, even when that's not the case. Default error reporting already prints an error message to console with the actual error. 

Also, state mutation can also happen outside reducers (selectors, etc, subscribers, etc), so there's no point in handling this case as special.